### PR TITLE
fix express regexp

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -130,7 +130,7 @@ router.get('/', (req, res) => {
 })
 
 // The catcher for all unknown routes.
-router.all('*', (req, res) => {
+router.all('/*splat', (req, res) => {
   console.warn('unknown route', req.method, req.originalUrl)
   res.status(501).send()
 })


### PR DESCRIPTION
with the current code, the error is:
```

/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:73
            throw new TypeError(`Missing parameter name at ${i}: ${DEBUG_URL}`);
                  ^

TypeError: Missing parameter name at 1: https://git.new/pathToRegexpError
    at name (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:73:19)
    at lexer (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:91:27)
    at lexer.next (<anonymous>)
    at Iter.peek (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:106:38)
    at Iter.tryConsume (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:112:28)
    at Iter.text (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:128:30)
    at consume (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:152:29)
    at parse (/workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:183:20)
    at /workspaces/redirectory/node_modules/path-to-regexp/dist/index.js:294:74
    at Array.map (<anonymous>)
```
the fix is explained in https://expressjs.com/en/guide/migrating-5.html#path-syntax