### PR TITLE
handle authentication needed situations

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -31,3 +31,7 @@ export function badGateway(message: string) {
 export function conflict(message: string) {
   return new Error(409, message)
 }
+
+export function authenticationException(message: string) {
+  return new Error(401, message)
+}

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { Octokit } from 'octokit'
-import { badRequest } from './http.js'
+import { badRequest, authenticationException } from './http.js'
 import { createOAuthAppAuth } from '@octokit/auth-oauth-app'
 
 const verbose = parseInt(process.env.VERBOSE) || 0
@@ -33,7 +33,7 @@ export function parseBearer(req) {
     if (user && auth) {
       return { user, auth }
     }
-    throw badRequest('Missing header: Authorization')
+    throw authenticationException('Missing header: Authorization')
   }
   const m1 = header.match(/^Bearer\s+(\S+?)\s*$/)
   if (!m1) {


### PR DESCRIPTION
When authentication is needed for some operations (upload recipe etc.), conan client relies on error code 401 to ask for authentication from the user
cf https://github.com/conan-io/conan/blob/3678ee1976d6a33af17462ddd0be2a8921077c8e/conans/server/rest/controller/v2/users.py#L36 and https://github.com/conan-io/conan/blob/3678ee1976d6a33af17462ddd0be2a8921077c8e/conans/client/rest/auth_manager.py#L67